### PR TITLE
[Sprint 93] ISY-650 IF2.x Auslesen X Correlation ID Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Enthält Backport der Dokumentation für DIN NORM 91379, IFS-1912, IFS-1467 und IFS-1628
   - Update aller AsciidoctorJ-Versionen
 - `ISY-658`: Abschnitt "Anmerkung zum Parallelbetrieb von AufrufKontextVerwalter und MdcHelper" hinzugefügt
+- `ISY-650`: Erklärung zum Überschreiben der `FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter>` ergänzt
 
 # 2.4.0
 - `IFS-546`: Vorgaben für Properties zu komplexen Datentypen ergänzt

--- a/src/docs/10_IsyFact-Standards/20_Bausteine/Nutzungsvorgaben_Logging/inhalt.adoc
+++ b/src/docs/10_IsyFact-Standards/20_Bausteine/Nutzungsvorgaben_Logging/inhalt.adoc
@@ -617,7 +617,46 @@ Darüber hinaus werden Methoden zum Kennzeichen der Inhalte im MDC als fachlich 
 ==== MDC-Filter
 
 Durch die Spring-Autokonfiguration in `isy-aufrufkontext` wird ein Servlet-Filter erstellt, welcher automatisch bei jedem Request die Korrelations-ID aus dem Http-Header ausliest und in den MDC setzt.
-Ist der Header nicht gesetzt, wird eine neue Korrelations-ID generiert.
+Ist der Header nicht gesetzt, wird eine neue Korrelations-ID generiert, indem die autokonfigurierte Bean <<listing-filterRegistrationBean-aufrufkontext>> aufgerufen wird.
+Das URL-Pattern "/*" schließt dabei alle URLs ein.
+
+[[listing-filterRegistrationBean-aufrufkontext]]
+.FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> aus isy-aufrufkontext
+[source,java]
+----
+@Bean
+FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> httpHeaderNestedDiagnosticContextFilter() {
+    FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> registrationBean = new FilterRegistrationBean<>();
+    registrationBean.setFilter(new HttpHeaderNestedDiagnosticContextFilter());
+    registrationBean.addUrlPatterns("/*");
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registrationBean;
+}
+----
+
+Falls HttpInvoker-Schnittstellen verwendet werden, muss diese Bean im Anwendungssystem so überschrieben werden, dass sie für die HttpInvoker-Schnittstellen deaktiviert ist.
+Grund dafür ist, dass bei HttpInvoker-Schnittstellen durch den Aufruf der Klasse IsyHttpInvokerClientInterceptor bereits eine Korrelations-ID generiert wird.
+Ohne das Überschreiben dieser Bean werden beim Aufruf einer HttpInvoker-Schnittstelle beide Mechanismen aktiv, sodass zwei neue Korrelations-IDs für eine einzige Aktion neu erzeugt werden.
+Dies ist zu vermeiden.
+
+Beim Überschreiben der Bean müssen die URL-Patterns so angegeben werden, dass die HttpInvoker-URLs nicht enthalten sind.
+Die Verwendung des Asterisk-Platzhalters * ist dabei am Ende des URL-Patterns möglich.
+Stellt eine Anwendung beispielsweise HttpInvoker-Schnittstellen unter `"/httpinv-endpoint0"` sowie REST-Schnittstellen unter `"/rest-endpoint1"`, `"/api/rest/example/endpoint2"` und `"/api/rest/example/endpoint3"` bereit, muss die Bean im Anwendungssystem wie folgt überschrieben werden:
+
+[[listing-filterRegistrationBean-anwendungssystem]]
+.Beispiel für Bean-Überschreibung im Anwendungssystem
+[source,java]
+----
+@Bean
+FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> httpHeaderNestedDiagnosticContextFilter() {
+    FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> registrationBean = new FilterRegistrationBean<>();
+    registrationBean.setFilter(new HttpHeaderNestedDiagnosticContextFilter());
+    registrationBean.addUrlPatterns("/rest-endpoint1", "/api/rest/example/*");
+    registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+    return registrationBean;
+}
+----
+Dadurch wird der `HttpHeaderNestedDiagnosticContextFilter` wie gewünscht nur für die REST-Schnittstellen aufgerufen.
 
 [[diagnosekontext-korrelations-id]]
 ==== Diagnosekontext / Korrelations-ID


### PR DESCRIPTION
feature/ISY-650-IF2.x-Auslesen-X-Correlation-ID-Header
* docs: ISY-381: backport documentation from antora-docs

    * includes docs for DIN NORM 91379, IFS-1912, IFS-1467 and IFS-1628
    * update moduleversion to 2.5.0
    * update asciidoctorj-versions and introduce maven-properties

* Merge pull request #8 from IsyFact/feature/ISY_381_Release-Isyfact-2.5.0

    [Sprint 91] ISY-381: Release Isyfact 2.5.0

* docs: ISY-650 describe overriding of FilterRegistrationBean<HttpHeaderNestedDiagnosticContextFilter> for HttpInvoker endpoints