### PR TITLE
[Sprint 93] ISY-658 StelltLoggingKontextBereit setzt generierte Korrelations ID nicht in AufrufKontextTo 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `IFS-381`: Release 2.5.0
   - Enthält Backport der Dokumentation für DIN NORM 91379, IFS-1912, IFS-1467 und IFS-1628
   - Update aller AsciidoctorJ-Versionen
+- `ISY-658`: Abschnitt "Anmerkung zum Parallelbetrieb von AufrufKontextVerwalter und MdcHelper" hinzugefügt
 
 # 2.4.0
 - `IFS-546`: Vorgaben für Properties zu komplexen Datentypen ergänzt

--- a/src/docs/10_IsyFact-Standards/20_Bausteine/Nutzungsvorgaben_Logging/inhalt.adoc
+++ b/src/docs/10_IsyFact-Standards/20_Bausteine/Nutzungsvorgaben_Logging/inhalt.adoc
@@ -648,6 +648,41 @@ Somit müssen alle Klassen, die das Interface Runnable implementieren, eine Meth
 Ansonsten besitzt der gestartete Thread nicht den Kontext des aufrufenden Threads.
 Zusätzlich muss im Thread eine weitere Unique-ID an die Korrelations-ID im MDC angehängt werden, so dass auch die Logeinträge des Threads eindeutig identifiziert werden können.
 
+*Anmerkung zum Parallelbetrieb von AufrufKontextVerwalter und MdcHelper*
+
+Innerhalb der Anwendung wird die Korrelations-ID sowohl über das AufrufKontext-Objekt im AufrufKontextVerwalter
+als auch über den MdcHelper verwaltet und zur Verfügung gestellt.
+
+An der Service-Schnittstelle werden dazu die Annotationen @StelltLoggingKontextBereit und @StelltAufrufKontextBereit
+in Zusammenspiel verwendet.
+
+Die Annotation @StelltLoggingKontextBereit liest die Korrelations-ID aus einem AufrufKontextTo, welches der annotierten
+Methode als Parameter übergeben wird und befüllt den Logging-Kontext, indem die Korrelations-ID in den MdcHelper geschrieben wird.
+
+Enthält das AufrufKontextTo keine (null) oder eine leere ("") Korrelations-ID, so wird eine neue Korrelations-ID generiert.
+Die neu generierte Korrelations-ID wird in das AufrufKontextTo-Objekt zurückgeschrieben und ebenfalls
+an den MdcHelper weitergegeben.
+
+Die @StelltLoggingKontextBereit-Annotation kann auch ohne vorhandenes AufrufKontextTo-Objekt verwendet werden.
+Dazu muss nutzeAufrufKontext auf false gesetzt werden.
+In diesem Fall wird eine neue Korrelations-ID generiert und in den MdcHelper geschrieben.
+
+Nach Aufruf des StelltLoggingKontextBereitInterceptors über die @StelltLoggingKontextBereit-Annotation
+ist die Korrelations-ID sowohl im MDC also auch im AufrufKontextTo vorhanden.
+
+Um die Daten des AufrufKontextTo in den AufrufKontextVerwalter zu schreiben, wird die Annotation @StelltAufrufKontextBereit
+verwendet.
+Im StelltAufrufKontextBereitInterceptor wird hierfür ein neues AufrufKontext-Objekt erstellt.
+Nach der Erstellung werden die Daten aus dem AufrufKontextTo in das AufrufKontext-Objekt übertragen und der AufrufKontext
+in den AufrufKontextVerwalter gesetzt.
+Der vorherige AufrufKontext wird hierbei zwischengespeichert und nach Aufruf der mit @StelltAufrufKontextBereit
+annotierten Methode wiederhergestellt.
+Entsprechend stehen die Daten aus dem AufrufKontextTo innerhalb des Methodenaufrufs in Form eines AufrufKontext-Objekts
+über den AufrufKontextVerwalter zur Verfügung.
+
+Nach dem Durchlaufen beider Interceptoren steht die Korrelations-ID sowohl im AufrufKontext(Verwalter) als auch über den
+MdcHelper zur Verfügung.
+
 [[konfiguration]]
 === Konfiguration
 


### PR DESCRIPTION
* docs: ISY-381: backport documentation from antora-docs

    * includes docs for DIN NORM 91379, IFS-1912, IFS-1467 and IFS-1628
    * update moduleversion to 2.5.0
    * update asciidoctorj-versions and introduce maven-properties

* Merge pull request #8 from IsyFact/feature/ISY_381_Release-Isyfact-2.5.0

    [Sprint 91] ISY-381: Release Isyfact 2.5.0

* docs: ISY-658 add comment about parallel usage of AufrufKontextVerwalter and MdcHelper with regards to logging and korrelationId
* chore: ISY-658 update changelog